### PR TITLE
Reorder menu items into logical groups

### DIFF
--- a/One Day Diet/ContentView.swift
+++ b/One Day Diet/ContentView.swift
@@ -63,9 +63,9 @@ struct ContentView: View {
                 HStack {
                     Spacer()
                     Menu {
-                        Button("😎 What's New?") { showVersionAlert = true }
                         Button("📊 Stats") { showStatsSheet = true }
                         Button("🙋 FAQ / About") { showFaqSheet = true }
+                        Button("😎 What's New?") { showVersionAlert = true }
                         Divider()
                         Button(showMacros ? "🧪 Hide Macro Tracking " : "🧪 Show Macro Tracking") {
                             showMacros.toggle()


### PR DESCRIPTION
## Summary
- Groups Stats, FAQ, and What's New together as informational items
- Groups Macro Tracking and Appearance together as settings
- Destructive actions remain at the bottom

## Test plan
- [ ] Open menu and verify order looks correct
- [ ] Confirm all items still function as expected