### PR TITLE
Bump version to 1.3.1 (build 21)

### DIFF
--- a/One Day Diet.xcodeproj/project.pbxproj
+++ b/One Day Diet.xcodeproj/project.pbxproj
@@ -14,14 +14,14 @@
 		EF4759562B4A469500BCE0EA /* One_Day_DietUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4759552B4A469500BCE0EA /* One_Day_DietUITests.swift */; };
 		EF4759582B4A469500BCE0EA /* One_Day_DietUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4759572B4A469500BCE0EA /* One_Day_DietUITestsLaunchTests.swift */; };
 		EF4759672B4A4F7800BCE0EA /* FoodGroupsData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4759662B4A4F7800BCE0EA /* FoodGroupsData.swift */; };
+		EF5757572B57575700575757 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5757562B57575700575757 /* StatsView.swift */; };
 		EF6DFB652B50E015004B376A /* TrackablesData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6DFB642B50E015004B376A /* TrackablesData.swift */; };
 		EF6DFB672B50E137004B376A /* TrackableStepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6DFB662B50E137004B376A /* TrackableStepperView.swift */; };
 		EF7BEC9A2B4B702900A30501 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7BEC992B4B702900A30501 /* ViewModel.swift */; };
 		EF88EDD72B4D99E4003D170E /* WhatsNewAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF88EDD62B4D99E4003D170E /* WhatsNewAlert.swift */; };
-		EFA1B0012B4D99E4003D170E /* ShakeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA1B0002B4D99E4003D170E /* ShakeDetector.swift */; };
-		EF5757572B57575700575757 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5757562B57575700575757 /* StatsView.swift */; };
 		EF88EDD92B4DA1C8003D170E /* FaqView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF88EDD82B4DA1C8003D170E /* FaqView.swift */; };
 		EF8C46C62B50268600CCF023 /* FoodGroupStepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8C46C52B50268600CCF023 /* FoodGroupStepperView.swift */; };
+		EFA1B0012B4D99E4003D170E /* ShakeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA1B0002B4D99E4003D170E /* ShakeDetector.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,15 +53,15 @@
 		EF4759552B4A469500BCE0EA /* One_Day_DietUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = One_Day_DietUITests.swift; sourceTree = "<group>"; };
 		EF4759572B4A469500BCE0EA /* One_Day_DietUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = One_Day_DietUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		EF4759662B4A4F7800BCE0EA /* FoodGroupsData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodGroupsData.swift; sourceTree = "<group>"; };
+		EF5757562B57575700575757 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 		EF6DFB642B50E015004B376A /* TrackablesData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackablesData.swift; sourceTree = "<group>"; };
 		EF6DFB662B50E137004B376A /* TrackableStepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableStepperView.swift; sourceTree = "<group>"; };
 		EF7A9CA32B5065DB000C1A34 /* One-Day-Diet-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "One-Day-Diet-Info.plist"; sourceTree = SOURCE_ROOT; };
 		EF7BEC992B4B702900A30501 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		EF88EDD62B4D99E4003D170E /* WhatsNewAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewAlert.swift; sourceTree = "<group>"; };
-		EFA1B0002B4D99E4003D170E /* ShakeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShakeDetector.swift; sourceTree = "<group>"; };
-		EF5757562B57575700575757 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 		EF88EDD82B4DA1C8003D170E /* FaqView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaqView.swift; sourceTree = "<group>"; };
 		EF8C46C52B50268600CCF023 /* FoodGroupStepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodGroupStepperView.swift; sourceTree = "<group>"; };
+		EFA1B0002B4D99E4003D170E /* ShakeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShakeDetector.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -454,7 +454,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "One Day Diet/One_Day_Diet.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"One Day Diet/Preview Content\"";
 				DEVELOPMENT_TEAM = 9ED5E567X5;
@@ -480,7 +480,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.1;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.One-Day-Diet";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -499,7 +499,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "One Day Diet/One_Day_Diet.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"One Day Diet/Preview Content\"";
 				DEVELOPMENT_TEAM = 9ED5E567X5;
@@ -525,7 +525,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.1;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.iammike.One-Day-Diet";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;


### PR DESCRIPTION
## Summary
- Version: 1.3.0 → 1.3.1
- Build: 20 → 21

## Test plan
- [ ] Archive builds successfully with correct version and build number